### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const {
   MODE_INPUT,
   PULL_UP,
   OUTPUT_HIGH
-} = require('@mrvanosh/mcp23s17');
+} = require('@mrvanosh/mcp23x17');
 
 (async () => {
   // MCP23S17 is on BUS 0 and it's device 0


### PR DESCRIPTION
Typo in code example. If the package was installed as suggested using :
"npm i @mrvanosh/mcp23x17"

Should be :
"require('@mrvanosh/mcp23x17')" 

Instead of :
"require('@mrvanosh/mcp23s17')"